### PR TITLE
Update settings_wifi.htm

### DIFF
--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -216,7 +216,7 @@ Static subnet mask:<br>
 				<option value="9">ABC! WLED V43 & compatible</option>
 				<option value="2">ESP32-POE</option>
 				<option value="11">ESP32-POE-WROVER</option>
-				<option value="6">ESP32Deux/RGB2Go Tetra</option>
+				<option value="6">ESP32Deux/RGB2Go</option>
 				<option value="7">KIT-VE</option>
 				<option value="12">LILYGO T-POE Pro</option>
 				<option value="8">QuinLED-Dig-Octa & T-ETH-POE</option>


### PR DESCRIPTION
Several of our controllers support the Ethernet module, so we figured it best to leave it as simply "RGB2Go" in the menu, as opposed to "RBG2Go" Tetra.